### PR TITLE
fixed: handle case where log note tag is not first page of tags

### DIFF
--- a/src/taskManager.ts
+++ b/src/taskManager.ts
@@ -352,14 +352,18 @@ export class TaskManager {
   }
 
   async getLogNotes() {
-    const tags = await this.joplin.data.get(['tags'], {
-      fields: ['id', 'title'],
+    // @todo: edge case exists where there may be more than 100 identical tags!
+    const tags = await this.joplin.data.get(['search'], {
+      query: this.logNoteTag,
+      fields: 'id,title',
+      type: 'tag',
     });
-    const timeTags = tags.items.filter(tag => tag.title === this.logNoteTag);
+    const timeTags = tags.items;
 
     if (timeTags.length > 0) {
       this.logNotes = [];
       for (const timeTag of timeTags) {
+        // @todo: there may also be more than 100 log notes
         const notes = await this.joplin.data.get(
           ['tags', timeTag.id, 'notes'],
           {


### PR DESCRIPTION
Modified API request to perform a `search` by the log note tag. 

* The problem still exists in the unusual case that the data has more than 100 duplicate tags with the title of the log note tag
* There is also an issue if there are more than 100 log notes