### PR TITLE
Feature/add totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ Time Slip is a [Joplin](https://joplinapp.org/) plugin that allows you to track 
 
 1. Create a new note and tag it with `time-slip`.
 2. Make sure that the note is selected in the Time Slip panel (you may need to switch to a different note first).
-3. Start a new timer by filling the task and project fields, and clicking the `Start` button. You may start multiple timers.
+3. Start a new timer by filling the task and project fields, and clicking the `Start` button.
+    - You may start multiple timers.
+    - Or you can enforce only one timer to be active.
+    - Task and Project can contain normal or markdown style links, which are clickable in the time slip view.
 4. Click the `Stop` button to stop the timer.
 5. The time log contains a table with entries for each ongoing or completed timer.
     - Edit the note to change any of the fields.

--- a/src/contentScripts/timeTracker.js
+++ b/src/contentScripts/timeTracker.js
@@ -39,11 +39,19 @@ function requestInitialData() {
   });
 }
 
-function formatEmbeddedURLs(unformatted) {
+function formatLinksAsHTML(unformatted) {
   if ( markdownRegex.test(unformatted) ) {
     return unformatted.replaceAll(markdownRegex, '<a href=$2 target="_blank">$1</a>');
   } else {
     return unformatted.replaceAll(urlRegex, '<a href=$1$2 target="_blank">$2</a>');
+  }
+}
+
+function formatLinksAsMarkdown(unformatted) {
+  if ( markdownRegex.test(unformatted) ) {
+    return unformatted;
+  } else {
+    return unformatted.replaceAll(urlRegex, '[$2]($1$2)');
   }
 }
 
@@ -92,8 +100,8 @@ function updateRunningTasksDisplay() {
       return `<div class="running-task">
         <div class="running-task-header">
           <div class="running-task-title-container">
-            <span class="running-task-title">${formatEmbeddedURLs(taskName)}</span>
-            <span class="running-task-project">${formatEmbeddedURLs(projectName)}</span>
+            <span class="running-task-title">${formatLinksAsHTML(taskName)}</span>
+            <span class="running-task-project">${formatLinksAsHTML(projectName)}</span>
           </div>
           <button class="stopButton" data-task="${taskName}" data-project="${projectName}">Stop</button>
         </div>
@@ -476,10 +484,10 @@ function buildTableRow(task, aggregationLevel, showBothColumns, formattedDuratio
   let rowHtml = '<tr>';
   
   if (aggregationLevel === 1) {
-    rowHtml += `<td>${formatEmbeddedURLs(originalTask)}</td>`;
-    rowHtml += `<td>${formatEmbeddedURLs(originalProject)}</td>`;
+    rowHtml += `<td>${formatLinksAsHTML(originalTask)}</td>`;
+    rowHtml += `<td>${formatLinksAsHTML(originalProject)}</td>`;
   } else if (aggregationLevel === 2) {
-    rowHtml += `<td>${formatEmbeddedURLs(name)}</td>`;
+    rowHtml += `<td>${formatLinksAsHTML(name)}</td>`;
   } else {
     rowHtml += `<td>${selectedNoteName || 'No note selected'}</td>`;
   }
@@ -601,9 +609,9 @@ function buildCsvRow(task, aggregationLevel, formattedDuration, csvFormattedEndT
   let csvRow = '';
   
   if (aggregationLevel === 1) {
-    csvRow = `${originalTask},${originalProject}`;
+    csvRow = `${formatLinksAsMarkdown(originalTask)},${formatLinksAsMarkdown(originalProject)}`;
   } else if (aggregationLevel === 2) {
-    csvRow = name;
+    csvRow = formatLinksAsMarkdown(name);
   } else {
     csvRow = selectedNoteName || 'No note selected';
   }
@@ -700,7 +708,9 @@ function updateCompletedTasksDisplay() {
     });
     if (currentAggregationLevel !== 3 && showDurationColumn && showTotalInSummary) {
       const formattedDuration = formatDuration(Math.floor(totalDuration / 1000));
-      tasksHtml += buildTableRow({name: 'Total', originalTask: '', originalProject: 'Total'}, currentAggregationLevel, showBothColumns, formattedDuration, '', 100);
+      let task = {name: 'Total', originalTask: '', originalProject: 'Total'};
+      csvContent += buildCsvRow(task, currentAggregationLevel, formattedDuration, '', 100);
+      tasksHtml += buildTableRow(task, currentAggregationLevel, showBothColumns, formattedDuration, '', 100);
     }
 
     tasksHtml += '</table>';

--- a/src/contentScripts/timeTracker.js
+++ b/src/contentScripts/timeTracker.js
@@ -91,7 +91,7 @@ function updateRunningTasksDisplay() {
         <div class="running-task-header">
           <div class="running-task-title-container">
             <span class="running-task-title">${formatEmbeddedURLs(taskName)}</span>
-            <span class="running-task-project">${projectName}</span>
+            <span class="running-task-project">${formatEmbeddedURLs(projectName)}</span>
           </div>
           <button class="stopButton" data-task="${taskName}" data-project="${projectName}">Stop</button>
         </div>
@@ -470,9 +470,9 @@ function buildTableRow(task, aggregationLevel, showBothColumns, formattedDuratio
   
   if (aggregationLevel === 1) {
     rowHtml += `<td>${formatEmbeddedURLs(originalTask)}</td>`;
-    rowHtml += `<td>${originalProject}</td>`;
+    rowHtml += `<td>${formatEmbeddedURLs(originalProject)}</td>`;
   } else if (aggregationLevel === 2) {
-    rowHtml += `<td>${name}</td>`;
+    rowHtml += `<td>${formatEmbeddedURLs(name)}</td>`;
   } else {
     rowHtml += `<td>${selectedNoteName || 'No note selected'}</td>`;
   }

--- a/src/contentScripts/timeTracker.js
+++ b/src/contentScripts/timeTracker.js
@@ -454,10 +454,18 @@ function buildTableHeader(aggregationLevel, showBothColumns) {
 
 function buildTableRow(task, aggregationLevel, showBothColumns, formattedDuration, formattedEndTime, percentage) {
   const { name, originalTask, originalProject } = task;
+  // Normal URL replacement and markdown replacement collide. (?<!\() doesn't seem to work as addition on normal regex.
+  let formattedTask = "";
+  const markdownRegex = /\[(.*?)\]\((.*?)\)/g;
+  if ( markdownRegex.test(originalTask) ) {
+    formattedTask = originalTask.replaceAll(markdownRegex, '<a href=$2 target="_blank">$1</a>');
+  } else {
+    formattedTask = originalTask.replaceAll(/(https?:\/\/.*\/)([-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)/g, '<a href=$1$2 target="_blank">$2</a>');
+  }
   let rowHtml = '<tr>';
   
   if (aggregationLevel === 1) {
-    rowHtml += `<td>${originalTask}</td>`;
+    rowHtml += `<td>${formattedTask}</td>`;
     rowHtml += `<td>${originalProject}</td>`;
   } else if (aggregationLevel === 2) {
     rowHtml += `<td>${name}</td>`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -205,6 +205,9 @@ joplin.plugins.register({
         await taskManager.updateEnforceSorting();
         await taskManager.scanNoteAndUpdateTasks();
       }
+      if (event.keys.includes('timeslip.onlyOneActiveTask')) {
+        await taskManager.updateOnlyOneActiveTask();
+      }
       if (event.keys.includes('timeslip.showDurationColumn') || 
           event.keys.includes('timeslip.showPercentageColumn') || 
           event.keys.includes('timeslip.showEndTimeColumn')) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,7 +210,9 @@ joplin.plugins.register({
       }
       if (event.keys.includes('timeslip.showDurationColumn') || 
           event.keys.includes('timeslip.showPercentageColumn') || 
-          event.keys.includes('timeslip.showEndTimeColumn')) {
+          event.keys.includes('timeslip.showEndTimeColumn') ||
+          event.keys.includes('timeslip.showTotalInSummary') ||
+          event.keys.includes('timeslip.showTotalInActiveTask') ) {
         await taskManager.updateColumnVisibility();
       }
     });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -111,7 +111,7 @@ export async function registerSettings() {
       type: SettingItemType.Bool,
       section: 'timeslip',
       public: true,
-      label: 'Only one actie taks',
+      label: 'Only one active taks',
       description: 'Stop all other pending tasks if a new task is started',
     },
   });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -106,6 +106,14 @@ export async function registerSettings() {
       label: 'Show end time column',
       description: 'Display the end time column in the completed tasks table',
     },
+    'timeslip.onlyOneActiveTask': {
+      value: false,
+      type: SettingItemType.Bool,
+      section: 'timeslip',
+      public: true,
+      label: 'Only one actie taks',
+      description: 'Stop all other pending tasks if a new task is started',
+    },
   });
 }
 
@@ -190,4 +198,8 @@ export async function getShowPercentageColumn(): Promise<boolean> {
 
 export async function getShowEndTimeColumn(): Promise<boolean> {
   return await joplin.settings.value('timeslip.showEndTimeColumn');
+}
+
+export async function getOnlyOneActiveTask(): Promise<boolean> {
+  return await joplin.settings.value('timeslip.onlyOneActiveTask');
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -106,6 +106,22 @@ export async function registerSettings() {
       label: 'Show end time column',
       description: 'Display the end time column in the completed tasks table',
     },
+    'timeslip.showTotalInSummary': {
+      value: true,
+      type: SettingItemType.Bool,
+      section: 'timeslip',
+      public: true,
+      label: 'Show total time in summary table',
+      description: 'Show a total of the durations in the duration column',
+    },
+    'timeslip.showTotalInActiveTask': {
+      value: false,
+      type: SettingItemType.Bool,
+      section: 'timeslip',
+      public: true,
+      label: 'Show total next to active task',
+      description: 'Adds the total duration of the summary table to the duration of the active task ans shows this next to the active task',
+    },
     'timeslip.onlyOneActiveTask': {
       value: false,
       type: SettingItemType.Bool,
@@ -198,6 +214,14 @@ export async function getShowPercentageColumn(): Promise<boolean> {
 
 export async function getShowEndTimeColumn(): Promise<boolean> {
   return await joplin.settings.value('timeslip.showEndTimeColumn');
+}
+
+export async function getShowTotalInSummary(): Promise<boolean> {
+  return await joplin.settings.value('timeslip.showTotalInSummary');
+}
+
+export async function getShowTotalInActiveTask(): Promise<boolean> {
+  return await joplin.settings.value('timeslip.showTotalInActiveTask');
 }
 
 export async function getOnlyOneActiveTask(): Promise<boolean> {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -111,7 +111,7 @@ export async function registerSettings() {
       type: SettingItemType.Bool,
       section: 'timeslip',
       public: true,
-      label: 'Only one active taks',
+      label: 'Only one active task',
       description: 'Stop all other pending tasks if a new task is started',
     },
   });

--- a/src/taskManager.ts
+++ b/src/taskManager.ts
@@ -1,6 +1,6 @@
 import { formatDuration, formatDate, formatTime, clearNoteReferences } from './utils';
 import { NoteManager } from './noteManager';
-import { getSummarySortOrder, getLogSortOrder, getEnforceSorting, getShowDurationColumn, getShowPercentageColumn, getShowEndTimeColumn, getOnlyOneActiveTask } from './settings';
+import { getSummarySortOrder, getLogSortOrder, getEnforceSorting, getShowDurationColumn, getShowPercentageColumn, getShowEndTimeColumn, getOnlyOneActiveTask, getShowTotalInSummary, getShowTotalInActiveTask } from './settings';
 import debounce = require('lodash.debounce');
 
 interface FieldIndices {
@@ -48,6 +48,8 @@ export class TaskManager {
   private showDurationColumn: boolean = true;
   private showPercentageColumn: boolean = true;
   private showEndTimeColumn: boolean = true;
+  private showTotalInSummary: boolean = true;
+  private showTotalInActiveTask: boolean = false;
 
   constructor(joplin: any, panel: string, noteId: string, noteManager: NoteManager) {
     this.joplin = joplin;
@@ -576,7 +578,9 @@ export class TaskManager {
       sortBy: this.sortBy,
       showDurationColumn: this.showDurationColumn,
       showPercentageColumn: this.showPercentageColumn,
-      showEndTimeColumn: this.showEndTimeColumn
+      showEndTimeColumn: this.showEndTimeColumn,
+      showTotalInSummary: this.showTotalInSummary,
+      showTotalInActiveTask: this.showTotalInActiveTask
     };
   }
 
@@ -647,13 +651,17 @@ export class TaskManager {
     this.showDurationColumn = await getShowDurationColumn();
     this.showPercentageColumn = await getShowPercentageColumn();
     this.showEndTimeColumn = await getShowEndTimeColumn();
+    this.showTotalInSummary = await getShowTotalInSummary();
+    this.showTotalInActiveTask = await getShowTotalInActiveTask();
     
     // Send the column visibility settings to the frontend
     this.joplin.views.panels.postMessage(this.panel, {
       name: 'updateColumnVisibility',
       showDurationColumn: this.showDurationColumn,
       showPercentageColumn: this.showPercentageColumn,
-      showEndTimeColumn: this.showEndTimeColumn
+      showEndTimeColumn: this.showEndTimeColumn,
+      showTotalInSummary: this.showTotalInSummary,
+      showTotalInActiveTask: this.showTotalInActiveTask
     });
   }
 }


### PR DESCRIPTION
There are three additions in this pull-request:

1. Adding totals to the completed tasks view and the active tasks view. This can be very helpful if your are on a time budget. The totals on the completed tasks view show the budget consumed by the completed tasks. This total will also be added to the active task(s) time, so you also see the total amount you're currently consuming.
2. Add support for clickable links in the Task Name field of a task. This can be either a normal link (where the last part of the link is used as visible part) or a markdown formatted link, where you can specify the visible part of the link. The example below has "https://jira.xyz.com/browse/CTAS-794639 MM crash" as Task Name.
3. An option to automatically close all running tasks when you start a new task. This makes life easier when you always only have one task active.

<img width="516" height="390" alt="image" src="https://github.com/user-attachments/assets/351b9607-5786-424f-bc54-0e1dadce0d47" />

And for the one active task option:
<img width="305" height="79" alt="image" src="https://github.com/user-attachments/assets/56d4bfdd-63b3-4e8f-8984-0153bd127309" />
Note: The typo has been fixed.

I noticed part of the fixes for the link support ended up in the wrong submit, but the total branch is about all three features (despite the name).